### PR TITLE
Handle JSON parse failures in ClientDetail

### DIFF
--- a/src/react-app/pages/ClientDetail.tsx
+++ b/src/react-app/pages/ClientDetail.tsx
@@ -174,15 +174,6 @@ export default function ClientDetail() {
     }
   };
 
-  const callClient = () => {
-    if (client?.phones) {
-      const phones = JSON.parse(client.phones);
-      if (phones.length > 0) {
-        window.location.href = `tel:${phones[0]}`;
-      }
-    }
-  };
-
   if (loading) {
     return (
       <div className="space-y-6">
@@ -241,9 +232,41 @@ export default function ClientDetail() {
     );
   }
 
-  const address = client.address ? JSON.parse(client.address) : null;
-  const emergencyContact = client.emergency_contact ? JSON.parse(client.emergency_contact) : null;
-  const phones = client.phones ? JSON.parse(client.phones) : [];
+  let address = null;
+  if (client.address) {
+    try {
+      address = JSON.parse(client.address);
+    } catch (err) {
+      console.warn('Failed to parse address JSON', err);
+      address = null;
+    }
+  }
+
+  let emergencyContact = null;
+  if (client.emergency_contact) {
+    try {
+      emergencyContact = JSON.parse(client.emergency_contact);
+    } catch (err) {
+      console.warn('Failed to parse emergency contact JSON', err);
+      emergencyContact = null;
+    }
+  }
+
+  let phones: string[] = [];
+  if (client.phones) {
+    try {
+      phones = JSON.parse(client.phones);
+    } catch (err) {
+      console.warn('Failed to parse phones JSON', err);
+      phones = [];
+    }
+  }
+
+  const callClient = () => {
+    if (phones.length > 0) {
+      window.location.href = `tel:${phones[0]}`;
+    }
+  };
 
   const tabs = [
     { id: 'overview', name: 'Overview', icon: User },


### PR DESCRIPTION
## Summary
- Safely parse client JSON fields with try/catch and fallbacks
- Use parsed phone numbers when placing calls

## Testing
- `npm test -- --run` *(fails: ReferenceError: document is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68babd720fa48322a121d5b53683dd67