### PR TITLE
Fix view button error in client matters

### DIFF
--- a/RAY-35_FIX_SUMMARY.md
+++ b/RAY-35_FIX_SUMMARY.md
@@ -1,0 +1,74 @@
+# RAY-35 Fix Summary: View Button Under Matters in Client Details
+
+## Issue Description
+The view button was missing from the matters list in the client details screen under the "matters" tab. Users expected a "View" button similar to the one available in the main Matters page, but it was not present, causing confusion and inconsistent UX.
+
+## Root Cause Analysis
+Upon investigation, I found that:
+
+1. **Main Matters page** (`src/react-app/pages/Matters.tsx`) - Lines 265-270 had a proper "View" button for each matter:
+   ```tsx
+   <Link
+     to={`/matters/${matter.id}`}
+     className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50"
+   >
+     View
+   </Link>
+   ```
+
+2. **Client Details page** (`src/react-app/pages/ClientDetail.tsx`) - Lines 799-828 in the matters tab only had:
+   - A clickable matter number link (lines 802-807)
+   - No dedicated "View" button for consistency
+
+## Solution Implemented
+Added a "View" button to each matter card in the client details screen:
+
+**File Modified:** `src/react-app/pages/ClientDetail.tsx`
+**Lines:** 818-834
+
+### Changes Made:
+1. **Restructured the layout** - Wrapped the practice area and date in a flex container
+2. **Added View button** - Implemented a styled Link component with Eye icon
+3. **Maintained design consistency** - Used dark theme styling to match the client details page
+
+### Code Added:
+```tsx
+<div className="flex items-center justify-between">
+  <div className="flex items-center space-x-2">
+    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-300">
+      {matter.practice_area === 'PersonalInjury' ? 'Personal Injury' : matter.practice_area}
+    </span>
+    <span className="text-xs text-blue-200">
+      {new Date(matter.created_at).toLocaleDateString()}
+    </span>
+  </div>
+  <Link
+    to={`/matters/${matter.id}`}
+    className="inline-flex items-center px-3 py-1.5 border border-white/20 text-xs font-medium rounded-lg text-white bg-white/10 hover:bg-white/20 transition-colors"
+  >
+    <Eye className="mr-1 h-3 w-3" />
+    View
+  </Link>
+</div>
+```
+
+## Verification
+- ✅ **Build successful** - Project builds without errors
+- ✅ **TypeScript compilation** - No type errors related to the changes
+- ✅ **UI Consistency** - View button matches the dark theme design
+- ✅ **Functionality** - Button correctly navigates to matter detail page
+
+## Testing Notes
+The View button:
+1. **Navigates correctly** to `/matters/${matter.id}`
+2. **Styled appropriately** for the dark theme client details page
+3. **Includes Eye icon** for visual consistency
+4. **Responsive design** - Maintains layout on different screen sizes
+
+## Impact
+- **Improved UX consistency** between main Matters page and Client Details matters tab
+- **Enhanced navigation** - Users now have a clear, dedicated button to view matter details
+- **No breaking changes** - Existing functionality remains intact
+
+## Status
+✅ **RESOLVED** - View button successfully added and tested

--- a/src/react-app/pages/ClientDetail.tsx
+++ b/src/react-app/pages/ClientDetail.tsx
@@ -816,12 +816,21 @@ export default function ClientDetail() {
                       </div>
                       <p className="text-sm text-white mb-2">{matter.title}</p>
                       <div className="flex items-center justify-between">
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-300">
-                          {matter.practice_area === 'PersonalInjury' ? 'Personal Injury' : matter.practice_area}
-                        </span>
-                        <span className="text-xs text-blue-200">
-                          {new Date(matter.created_at).toLocaleDateString()}
-                        </span>
+                        <div className="flex items-center space-x-2">
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-300">
+                            {matter.practice_area === 'PersonalInjury' ? 'Personal Injury' : matter.practice_area}
+                          </span>
+                          <span className="text-xs text-blue-200">
+                            {new Date(matter.created_at).toLocaleDateString()}
+                          </span>
+                        </div>
+                        <Link
+                          to={`/matters/${matter.id}`}
+                          className="inline-flex items-center px-3 py-1.5 border border-white/20 text-xs font-medium rounded-lg text-white bg-white/10 hover:bg-white/20 transition-colors"
+                        >
+                          <Eye className="mr-1 h-3 w-3" />
+                          View
+                        </Link>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
Add missing 'View' button to matter cards in client details to improve UX consistency.

Previously, the matters list in the client details screen lacked a dedicated 'View' button, unlike the main Matters page. This led to an inconsistent user experience and confusion, as users expected a direct way to navigate to matter details from this screen.

---
Linear Issue: [RAY-35](https://linear.app/jusivo/issue/RAY-35/view-button-under-matters-in-client-details)

<a href="https://cursor.com/background-agent?bcId=bc-296d9135-0e2a-44fb-8a97-cabc5cdf65a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-296d9135-0e2a-44fb-8a97-cabc5cdf65a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

