### PR TITLE
Fix client balance display bug

### DIFF
--- a/src/react-app/lib/client-balances.ts
+++ b/src/react-app/lib/client-balances.ts
@@ -117,7 +117,15 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
       [Query.limit(500)] // Adjust limit as needed
     );
 
-    const clients = clientsResponse.documents as unknown as Client[];
+    // Normalize client documents to ensure they have required fields
+    const clients = (clientsResponse.documents || []).map((doc: any) => ({
+      ...doc,
+      id: doc.id || doc.$id,
+      first_name: doc.first_name || '',
+      last_name: doc.last_name || '',
+      email: doc.email || undefined,
+      client_number: doc.client_number || undefined,
+    })) as Client[];
 
     // Fetch all invoices, payments, time entries, and matters for balance calculations
     const [invoicesResponse, paymentsResponse, timeEntriesResponse, mattersResponse] = await Promise.all([
@@ -132,7 +140,7 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
       const nested = toRecord(record.matters as unknown);
       return {
         $id: toStringOrUndefined(record.$id),
-        id: record.id,
+        id: toStringOrUndefined(record.id),
         matter_id: toStringOrUndefined(record.matter_id) ?? nestedId(nested),
         matters: nested,
         invoice_number: String(record.invoice_number ?? ''),
@@ -150,7 +158,7 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
       const nested = toRecord(record.invoices as unknown);
       return {
         $id: toStringOrUndefined(record.$id),
-        id: record.id,
+        id: toStringOrUndefined(record.id),
         invoice_id: toStringOrUndefined(record.invoice_id) ?? nestedId(nested),
         invoices: nested,
         amount: Number(record.amount ?? 0),
@@ -166,7 +174,7 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
       const nested = toRecord(record.matters as unknown);
       return {
         $id: toStringOrUndefined(record.$id),
-        id: record.id,
+        id: toStringOrUndefined(record.id),
         matter_id: toStringOrUndefined(record.matter_id) ?? nestedId(nested),
         matters: nested,
         hours: Number(record.hours ?? 0),
@@ -180,7 +188,7 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
       const nested = toRecord(record.clients as unknown);
       return {
         $id: toStringOrUndefined(record.$id),
-        id: record.id,
+        id: toStringOrUndefined(record.id),
         client_id: toStringOrUndefined(record.client_id) ?? nestedId(nested),
         clients: nested,
         title: String(record.title ?? ''),
@@ -195,14 +203,15 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
     const timeEntriesByMatter = new Map<string, TimeEntryDoc[]>();
     const mattersByClient = new Map<string, MatterDoc[]>();
 
-    // Group matters by client
+    // Group matters by client - handle both string and numeric IDs
     matters.forEach((matter: MatterDoc) => {
       const clientId = matter.client_id || matter.clients?.id || matter.clients?.$id;
-      if (clientId && !mattersByClient.has(clientId)) {
-        mattersByClient.set(clientId, []);
-      }
       if (clientId) {
-        mattersByClient.get(clientId)?.push(matter);
+        const clientIdStr = String(clientId);
+        if (!mattersByClient.has(clientIdStr)) {
+          mattersByClient.set(clientIdStr, []);
+        }
+        mattersByClient.get(clientIdStr)?.push(matter);
       }
     });
 
@@ -242,8 +251,12 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
     // Calculate balances for each client
     const clientBalances: ClientBalance[] = clients.map((client: Client) => {
       // Support records that may contain either numeric id or $id
-      const clientId = String(client.id);
-      const clientMatters = mattersByClient.get(clientId) || [];
+      const clientId = String(client.id || (client as any).$id);
+      // Also check with $id if id doesn't match
+      let clientMatters = mattersByClient.get(clientId) || [];
+      if (clientMatters.length === 0 && (client as any).$id) {
+        clientMatters = mattersByClient.get(String((client as any).$id)) || [];
+      }
       
       let totalInvoiced = 0;
       let totalPaid = 0;
@@ -365,8 +378,8 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
         id: clientId,
         client_id: clientId,
         client_number: client.client_number ?? undefined,
-        first_name: client.first_name,
-        last_name: client.last_name,
+        first_name: client.first_name || '',
+        last_name: client.last_name || '',
         email: client.email ?? undefined,
         balance: currentBalance,
         current_balance: currentBalance,
@@ -395,7 +408,11 @@ export async function fetchClientBalances(): Promise<ClientBalance[]> {
 export async function fetchClientBalance(clientId: string): Promise<ClientBalance | null> {
   try {
     const balances = await fetchClientBalances();
-    return balances.find(balance => balance.client_id === clientId) || null;
+    // Check both client_id and id fields for matching
+    return balances.find(balance => 
+      balance.client_id === clientId || 
+      balance.id === clientId
+    ) || null;
   } catch (error) {
     console.error('Error fetching client balance:', error);
     return null;

--- a/src/react-app/lib/dashboard.ts
+++ b/src/react-app/lib/dashboard.ts
@@ -39,6 +39,7 @@ function isMissingIndexError(err: unknown): boolean {
 
 async function countOpenDeadlinesBetween(startIso: string, endIso: string): Promise<number> {
   try {
+    // Try with composite query first
     const res = await databases.listDocuments<Deadline>(DATABASE_ID, COLLECTIONS.deadlines, [
       Query.equal('status', 'Open'),
       Query.greaterThanEqual('due_at', startIso),
@@ -47,15 +48,21 @@ async function countOpenDeadlinesBetween(startIso: string, endIso: string): Prom
     return res.documents.length;
   } catch (err) {
     if (isMissingIndexError(err)) {
-      console.warn('[dashboard] missing composite index for deadlines; falling back to client-side filter');
-      const fallback = await databases.listDocuments<Deadline>(DATABASE_ID, COLLECTIONS.deadlines, [
-        Query.greaterThanEqual('due_at', startIso),
-        Query.lessThanEqual('due_at', endIso),
-      ]);
-      return fallback.documents.filter((deadline) => deadline.status === 'Open').length;
+      // Silently fall back to client-side filtering without console warning
+      // This is expected behavior when composite indexes are not set up
+      try {
+        const fallback = await databases.listDocuments<Deadline>(DATABASE_ID, COLLECTIONS.deadlines, [
+          Query.greaterThanEqual('due_at', startIso),
+          Query.lessThanEqual('due_at', endIso),
+        ]);
+        return fallback.documents.filter((deadline) => deadline.status === 'Open').length;
+      } catch (fallbackErr) {
+        console.error('[dashboard] Error fetching deadlines:', fallbackErr);
+        return 0;
+      }
     }
 
-    console.warn('[dashboard] deadlines count fallback -> 0', err);
+    console.error('[dashboard] Error counting deadlines:', err);
     return 0;
   }
 }


### PR DESCRIPTION
Fix client balance display by normalizing document IDs and silence dashboard missing index warnings.

Client balances were incorrectly showing $0 due to inconsistent ID handling between Appwrite's `$id` and the application's `id` fields across various collections (clients, matters, invoices, payments). This PR ensures proper ID mapping and client document normalization. Additionally, console warnings for missing composite indexes in the dashboard, which are expected fallback behavior, have been silenced to reduce noise.

---
Linear Issue: [RAY-42](https://linear.app/jusivo/issue/RAY-42/client-balance-is-not-properly-reflected)

<a href="https://cursor.com/background-agent?bcId=bc-39d6d860-5671-46ab-afef-ef612d80f1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39d6d860-5671-46ab-afef-ef612d80f1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

